### PR TITLE
[Issue] Nicknames with spaces

### DIFF
--- a/src/LeagueAPI/LeagueAPI.php
+++ b/src/LeagueAPI/LeagueAPI.php
@@ -1479,7 +1479,6 @@ class LeagueAPI extends BaseAPI
 	 */
 	public function getSummonerByName( string $summoner_name )
 	{
-		$summoner_name = str_replace(' ', '', $summoner_name);
 		if (trim($summoner_name) === '') {
 			throw new RequestParameterException('Provided summoner name must not be empty');
 		}


### PR DESCRIPTION
I am Korean and I have confirmed that there is a space in the nickname for the Korean region.
Therefore, the spaces between nicknames should not be removed.

https://www.op.gg/summoner/userName=%EC%95%84+%EB%AC%98

See the site above.